### PR TITLE
fix(core): Resolve TypeScript errors in card-logic

### DIFF
--- a/packages/core/src/card-logic.ts
+++ b/packages/core/src/card-logic.ts
@@ -34,22 +34,16 @@ export function getGitHubMetrics(user: GitHubUser, repos: GitHubRepo[]): GitHubM
  * This function maps the raw repo data to the fields defined in TopReposData (via RepoDisplayData).
  */
 export function getTopRepos(repos: GitHubRepo[]): TopReposData {
-  return repos.map(repo => ({
-    // Map to the fields expected by RepoDisplayData, which TopReposData uses.
-    // id is not in RepoDisplayData, so it's removed if TopReposData strictly follows RepoGridDisplayData -> RepoDisplayData.
-    // However, TopReposData was originally defined as Array<Pick<GitHubRepo, 'name' | 'description' | 'stargazers_count' | 'language' | 'html_url' | 'id'>>;
-    // The current card-types.ts has TopReposData = RepoGridDisplayData, and RepoGridDisplayData.repos is Array<RepoDisplayData>.
-    // RepoDisplayData now includes id.
+  const mappedReposArray: RepoDisplayData[] = repos.map(repo => ({
     id: repo.id,
     name: repo.name,
     description: repo.description,
     stargazers_count: repo.stargazers_count,
-    forks_count: repo.forks_count, // forks_count is in GitHubRepo and RepoDisplayData
+    forks_count: repo.forks_count,
     language: repo.language,
     html_url: repo.html_url,
   }));
-  // Since TopReposData is an alias for RepoGridDisplayData, the return type should be { repos: Array<RepoDisplayData> }
-  return { repos: mappedRepos };
+  return { repos: mappedReposArray };
 }
 
 


### PR DESCRIPTION
This commit fixes two TypeScript errors in `packages/core/src/card-logic.ts`:

1.  Resolved `TS2741: Property 'repos' is missing...` in the `getTopRepos` function. The function was returning an array directly, but its type `TopReposData` (an alias for `RepoGridDisplayData`) expects an object of the shape `{ repos: RepoDisplayData[] }`. The function now correctly returns the mapped array wrapped in this object structure.

2.  Resolved `TS2304: Cannot find name 'mappedRepos'` in the same `getTopRepos` function. This was a typo where an undefined variable `mappedRepos` was used. It has been corrected to use the properly defined `mappedReposArray` variable.

These changes ensure that the DTS build for the `core` package completes successfully.