### PR TITLE
fix(mantine-demo): Resolve build errors and ensure demo app works

### DIFF
--- a/apps/mantine-demo/index.html
+++ b/apps/mantine-demo/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mantine Demo</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+</html>

--- a/apps/mantine-demo/src/App.tsx
+++ b/apps/mantine-demo/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Container, TextField, Button, Stack, Title, Paper, Group, Text, Code } from '@mantine/core';
+import { Container, TextInput, Button, Stack, Title, Paper, Group, Text, Code } from '@mantine/core';
 import { ProfileCard, LanguageUsageCard, SingleRepoCard } from '@github-profile-cards/react-mantine';
 
 // A mock token for development - replace with a real one if needed for private repo testing
@@ -88,7 +88,7 @@ function App() {
 
       <Paper shadow="xs" p="md" mb="xl">
         <Group>
-          <TextField
+          <TextInput
             label="GitHub Username"
             placeholder="Enter GitHub username"
             value={inputValue}


### PR DESCRIPTION
This commit addresses build failures in the `apps/mantine-demo` application:

1.  **Added Missing Entry Point:**
    - Created a standard `index.html` file in `apps/mantine-demo`, which was missing and caused the initial Vite build failure (`Could not resolve entry module "index.html"`).

2.  **Corrected Mantine Import:**
    - Fixed an import error in `apps/mantine-demo/src/App.tsx` by changing the incorrect `TextField` import from `@mantine/core` to the correct `TextInput`. This resolved the primary build error after the `index.html` was added.

With these changes, the `apps/mantine-demo` application now successfully passes `typecheck`, `lint`, and `build` scripts.