### PR TITLE
Fix: Resolve "process is not defined" error in browser environments

### DIFF
--- a/packages/core/src/github-api.ts
+++ b/packages/core/src/github-api.ts
@@ -79,7 +79,7 @@ export async function fetchGitHubData(
     throw new InvalidRequestError('GitHub username is required.');
   }
 
-  const apiToken = token || process.env.GITHUB_TOKEN;
+  const apiToken = token;
   const headers: HeadersInit = {
     Accept: 'application/vnd.github.v3+json',
   };
@@ -189,7 +189,7 @@ export async function fetchGenericGitHubAPI<T>(
   url: string,
   token?: string
 ): Promise<T> {
-  const apiToken = token || process.env.GITHUB_TOKEN;
+  const apiToken = token;
   const headers: HeadersInit = {
     Accept: 'application/vnd.github.v3+json',
   };


### PR DESCRIPTION
The GitHub API functions in `packages/core/src/github-api.ts` were attempting to fall back to `process.env.GITHUB_TOKEN` when a token argument was not provided. This caused a "process is not defined" runtime error in browser-based demos.

This commit removes the fallback to `process.env.GITHUB_TOKEN` in `fetchGitHubData` and `fetchGenericGitHubAPI`. The API token must now be explicitly passed as an argument if needed.

This resolves the error and allows the demos to run without crashing, though further investigation is needed for silent data loading failures in some demos.