### PR TITLE
fix(web-components): Correct sideEffects in package.json

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -6,8 +6,10 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "sideEffects": [
-    "./dist/index.js",
-    "./dist/index.mjs"
+    "./src/index.ts",
+    "./src/profile-card-wc.ts",
+    "./src/single-repo-card-wc.ts",
+    "./src/language-usage-card-wc.ts"
   ],
   "exports": {
     ".": {


### PR DESCRIPTION
Updates the sideEffects field in packages/web-components/package.json to correctly list the source files that register custom elements. This prevents the build system from incorrectly tree-shaking the component definitions, which was causing them not to load in the demos.