### PR TITLE
fix(web-components): Correct order of conditions in package.json exports

### DIFF
--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -13,9 +13,9 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     }
   },
   "files": [


### PR DESCRIPTION
Adjusts the order of conditions in the 'exports' map in packages/web-components/package.json to place 'types' first. This resolves build warnings and aligns with recommended practices.