### PR TITLE
fix(core): Correct order of conditions in package.json exports

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,9 +8,9 @@
   "sideEffects": false,
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     }
   },
   "files": [


### PR DESCRIPTION
Adjusts the order of conditions in the 'exports' map in packages/core/package.json to place 'types' first. This aligns with recommended practices and ensures consistent package resolution.